### PR TITLE
Add interactive choropleth map for state counties based on selected USDA features

### DIFF
--- a/preprocess_data_for_covid_counties.ipynb
+++ b/preprocess_data_for_covid_counties.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from datetime import date"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Read clean covid, fips, and usda data from local saved csv files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "confirmed_cumulative_cases_county = pd.read_csv(\"data/covid_usafacts/clean/confirmed_cumulative_cases_fips.csv\", index_col=0)\n",
+    "confirmed_daily_incidence_cases_county = pd.read_csv(\"data/covid_usafacts/clean/confirmed_daily_incidence_cases_fips.csv\", index_col=0)\n",
+    "cumulative_deaths_county = pd.read_csv(\"data/covid_usafacts/clean/cumulative_deaths_fips.csv\", index_col=0)\n",
+    "daily_incidence_deaths_county = pd.read_csv(\"data/covid_usafacts/clean/daily_incidence_deaths_fips.csv\", index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ny_usda_data = pd.read_csv(\"data/usda_county_datasets/clean/ny_counties.csv\", index_col=0)\n",
+    "pa_usda_data = pd.read_csv(\"data/usda_county_datasets/clean/pa_counties.csv\", index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "county_fips = pd.read_csv(\"data/covid_usafacts/clean/county_fips_2019.csv\", index_col=0)\n",
+    "state_fips = pd.read_excel(\"data/covid_usafacts/raw/state_fips_2019.xlsx\", skiprows=range(5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ny_daily_cases = pd.read_csv(\"data/covid_counties/ny_daily_cases.csv\", index_col=0)\n",
+    "ny_daily_deaths = pd.read_csv(\"data/covid_counties/ny_daily_deaths.csv\", index_col=0)\n",
+    "pa_daily_cases = pd.read_csv(\"data/covid_counties/pa_daily_cases.csv\", index_col=0)\n",
+    "pa_daily_deaths = pd.read_csv(\"data/covid_counties/pa_daily_deaths.csv\", index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convert date str columns to date objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ny_daily_cases[\"time_value\"] = ny_daily_cases[\"time_value\"].apply(date.fromisoformat)\n",
+    "ny_daily_cases[\"issue\"] = ny_daily_cases[\"issue\"].apply(date.fromisoformat)\n",
+    "\n",
+    "ny_daily_deaths[\"time_value\"] = ny_daily_deaths[\"time_value\"].apply(date.fromisoformat)\n",
+    "ny_daily_deaths[\"issue\"] = ny_daily_deaths[\"issue\"].apply(date.fromisoformat)\n",
+    "\n",
+    "pa_daily_cases[\"time_value\"] = pa_daily_cases[\"time_value\"].apply(date.fromisoformat)\n",
+    "pa_daily_cases[\"issue\"] = pa_daily_cases[\"issue\"].apply(date.fromisoformat)\n",
+    "\n",
+    "pa_daily_deaths[\"time_value\"] = pa_daily_deaths[\"time_value\"].apply(date.fromisoformat)\n",
+    "pa_daily_deaths[\"issue\"] = pa_daily_deaths[\"issue\"].apply(date.fromisoformat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_rows_in_date_range(df, date_col, start_date, end_date):\n",
+    "    return df[(df[date_col] >= start_date) & (df[date_col] <= end_date)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_rows_in_date_range(ny_daily_cases, \"time_value\", date(2020, 10, 1), date(2020, 11, 1))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,19 +3,65 @@ import streamlit as st
 
 import twitter.word_cloud
 
+import pandas as pd
+import altair as alt
+from vega_datasets import data
+
 DATA_DIR = "data"
 
 
-def draw_wordcloud():
+@st.cache(allow_output_mutation=True)
+def get_wordcloud():
     wc = twitter.word_cloud.main(DATA_DIR)
     fig, ax = plt.subplots()
     ax.imshow(wc, interpolation='bilinear')
     ax.axis("off")
-    st.pyplot(fig)
+    return fig
+
+
+@st.cache(allow_output_mutation=True)  # add caching so we load the data only once
+def load_state_fips():
+    state_fips_df = pd.read_excel("data/covid_usafacts/raw/state_fips_2019.xlsx", skiprows=range(5))
+    state_fips_df = state_fips_df[state_fips_df["State (FIPS)"] > 0]  # exclude regions, divisions, and non-state rows
+    return state_fips_df[["State (FIPS)", "Name"]].sort_values("Name").set_index("Name").to_dict()["State (FIPS)"]
+
+
+@st.cache(allow_output_mutation=True)
+def load_state_usda():
+    state_usda_dict = {
+        "New York": pd.read_csv("data/usda_county_datasets/clean/ny_counties.csv", index_col=0),
+        "Pennsylvania": pd.read_csv("data/usda_county_datasets/clean/pa_counties.csv", index_col=0)
+    }
+    return state_usda_dict
+
+
+def draw_state_counties():
+    state_usda_dict = load_state_usda()
+    state_fips_dict = load_state_fips()
+
+    states = list(state_usda_dict.keys())
+    selected_state = st.selectbox('State', options=states, index=states.index("New York"))
+
+    usda_df = state_usda_dict.get(selected_state)
+    usda_features = [col for col in usda_df.columns if col not in ['FIPS', 'Name']]
+    selected_usda_feature = st.selectbox('Based on', options=usda_features, index=0)
+
+    counties = alt.topo_feature(data.us_10m.url, 'counties')
+    state_map = alt.Chart(data=counties).mark_geoshape(stroke='black', strokeWidth=1) \
+        .encode(color="%s:Q" % selected_usda_feature,
+                tooltip=[alt.Tooltip('id:N', title='FIPS'),
+                         alt.Tooltip('Name:N', title='County')]) \
+        .transform_calculate(state_id="(datum.id / 1000)|0") \
+        .transform_filter(alt.datum.state_id == state_fips_dict[selected_state]) \
+        .transform_lookup(lookup='id', from_=alt.LookupData(usda_df, 'FIPS', [selected_usda_feature, 'Name'])) \
+        .properties(width=650, height=650)
+    st.write(state_map)
 
 
 def main():
-    draw_wordcloud()
+    wordcloud = get_wordcloud()
+    st.pyplot(wordcloud)
+    draw_state_counties()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #8 

This pull request adds interactive choropleth maps for NY and PA to the streamlit app. Counties are colored based on the selected USDA feature in the dropdown bar. A tooltip shows the FIPS code and name of the county being hovered over.

Also adds cache tag to draw_wordcloud function to only retrieve it once when running the app.